### PR TITLE
Add parameter for ingress protocol annotation key name

### DIFF
--- a/templates/conduits.yaml
+++ b/templates/conduits.yaml
@@ -186,12 +186,12 @@ metadata:
 
     {{ if hasKey $targetService.service "tls" }}
       {{ if not $targetService.service.tls }}
-    ingress.kubernetes.io/protocol: "http"
+    {{ $ingressDefaults.backendProtocolAnnotationKey }}: "http"
       {{ else }}
-    ingress.kubernetes.io/protocol: "https"
+    {{ $ingressDefaults.backendProtocolAnnotationKey }}: "https"
       {{ end }}
     {{ else }}
-    ingress.kubernetes.io/protocol: "https"
+    {{ $ingressDefaults.backendProtocolAnnotationKey }}: "https"
     {{ end }}
 
     traefik.ingress.kubernetes.io/service-weights: |

--- a/values.yaml
+++ b/values.yaml
@@ -198,6 +198,10 @@ ingress:
   # into the ingress object
   pathType: ""
 
+  # name of annotation key that tells the ingress controller
+  # if backend is http or https
+  backendProtocolAnnotationKey: "ingress.kubernetes.io"
+
   # the ingressClassName required for networking.k8s.io/v1
   # otherwise defaults to nothing (empty string), won't be applied
   # this CANNOT co-exist w/ annotation "kubernetes.io/ingress.class"


### PR DESCRIPTION
Customizable value to set the ingress annotation key name for backend protocol. Need this to support other ingress controllers. For example, ingress-nginx, which uses `nginx.ingress.kubernetes.io/backend-protocol` rather than `ingress.kubernetes.io`