### PR TITLE
Remove default ingress class

### DIFF
--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -202,3 +202,8 @@ conduits:
               serviceBindings:
                 hog1: "50%"
                 hog2: "50%"
+
+ingress:
+  metadata:
+    annotations:
+      kubernetes.io/ingress.class: "traefik"

--- a/values.yaml
+++ b/values.yaml
@@ -240,7 +240,7 @@ ingress:
     # TODO: get rid of this default, traefik specific
     # tpl variable substitution supported in values here. See README
     annotations:
-      kubernetes.io/ingress.class: "traefik"
+      #kubernetes.io/ingress.class: "traefik"
       #annotationName2: "something" # PARSED by Helm 'tpl' function passed $
 
   # The tls config defined here if enabled, will be applied to each


### PR DESCRIPTION
Having a default kubernetes.io/ingress.class annotation can conflict when you're trying to use ingressClassName